### PR TITLE
Set up CORS and OAuth2 Resource Server for Spring API

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,6 +53,18 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/tokorokoshi/tokoro/security/AudienceValidator.java
+++ b/backend/src/main/java/com/tokorokoshi/tokoro/security/AudienceValidator.java
@@ -1,0 +1,23 @@
+package com.tokorokoshi.tokoro.security;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+    private final String audience;
+
+    public AudienceValidator(String audience) {
+        this.audience = audience;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        if (jwt.getAudience().contains(audience)) {
+            return OAuth2TokenValidatorResult.success();
+        }
+        return OAuth2TokenValidatorResult.failure(
+                new OAuth2Error("invalid_token", "The required audience is missing", null));
+    }
+}

--- a/backend/src/main/java/com/tokorokoshi/tokoro/security/CorsConfig.java
+++ b/backend/src/main/java/com/tokorokoshi/tokoro/security/CorsConfig.java
@@ -1,0 +1,52 @@
+package com.tokorokoshi.tokoro.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+@Configuration
+public class CorsConfig {
+    @Value("${cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(Arrays.asList(allowedOrigins));
+
+        config.setAllowedMethods(Arrays.asList(
+                "GET",
+                "POST",
+                "PUT",
+                "DELETE",
+                "PATCH",
+                "OPTIONS"
+        ));
+
+        config.setAllowedHeaders(Arrays.asList(
+                "Authorization",
+                "Content-Type",
+                "Accept",
+                "Origin",
+                "X-Requested-With"
+        ));
+
+        config.setExposedHeaders(Arrays.asList(
+                "Authorization",
+                "Content-Disposition"
+        ));
+
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
@@ -1,0 +1,87 @@
+package com.tokorokoshi.tokoro.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Objects;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final Environment env;
+    private final CorsConfigurationSource corsConfigurationSource;
+
+    @Autowired
+    SecurityConfig(Environment env, CorsConfigurationSource corsConfigurationSource) {
+        this.env = env;
+        this.corsConfigurationSource = corsConfigurationSource;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        if (isProduction()) {
+            http
+                    .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                    .oauth2ResourceServer(oauth2 -> oauth2
+                            .jwt(jwt -> jwt.decoder(jwtDecoder()))
+                    );
+
+            http.authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/error").permitAll()
+                    .requestMatchers("/actuator/health").permitAll()
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    .requestMatchers("/api/**").authenticated()
+                    .anyRequest().denyAll()
+            );
+        } else {
+            http
+                    .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                    .authorizeHttpRequests(auth -> auth
+                            .anyRequest().permitAll()
+                    );
+        }
+
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    private boolean isProduction() {
+        String[] activeProfiles = env.getActiveProfiles();
+        for (String profile : activeProfiles) {
+            if (profile.equals("prod")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Bean
+    @Profile("prod")
+    JwtDecoder jwtDecoder() {
+        String issuer = env.getProperty("auth0.issuer");
+        String audience = env.getProperty("auth0.audience");
+
+        NimbusJwtDecoder jwtDecoder = JwtDecoders.fromOidcIssuerLocation(Objects.requireNonNull(issuer));
+
+        OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(audience);
+        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuer);
+        OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);
+
+        jwtDecoder.setJwtValidator(withAudience);
+
+        return jwtDecoder;
+    }
+}

--- a/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -33,28 +32,21 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         if (isProduction()) {
-            http
-                    .cors(cors -> cors.configurationSource(corsConfigurationSource))
-                    .oauth2ResourceServer(oauth2 -> oauth2
-                            .jwt(jwt -> jwt.decoder(jwtDecoder()))
-                    );
-
-            http.authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/error").permitAll()
-                    .requestMatchers("/actuator/health").permitAll()
-                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                    .requestMatchers("/api/**").authenticated()
-                    .anyRequest().denyAll()
-            );
+            http.cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())))
+                .authorizeHttpRequests(auth ->
+                        auth.requestMatchers("/error").permitAll()
+                            .requestMatchers("/actuator/health").permitAll()
+                            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                            .requestMatchers("/api/**").authenticated()
+                            .anyRequest().denyAll()
+                );
         } else {
-            http
-                    .cors(cors -> cors.configurationSource(corsConfigurationSource))
-                    .authorizeHttpRequests(auth -> auth
-                            .anyRequest().permitAll()
-                    );
+            http.cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .authorizeHttpRequests(auth ->
+                        auth.anyRequest().permitAll()
+                );
         }
-
-        // CSRF protection is enabled by default, no need to disable it
 
         return http.build();
     }

--- a/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                     );
         }
 
-        http.csrf(AbstractHttpConfigurer::disable);
+        // CSRF protection is enabled by default, no need to disable it
 
         return http.build();
     }

--- a/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
+++ b/backend/src/main/java/com/tokorokoshi/tokoro/security/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 @Configuration
@@ -59,13 +60,7 @@ public class SecurityConfig {
     }
 
     private boolean isProduction() {
-        String[] activeProfiles = env.getActiveProfiles();
-        for (String profile : activeProfiles) {
-            if (profile.equals("prod")) {
-                return true;
-            }
-        }
-        return false;
+        return Arrays.stream(env.getActiveProfiles()).anyMatch("prod"::equals);
     }
 
     @Bean

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+cors:
+  allowed-origins: http://localhost:8080

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,6 +1,2 @@
-spring:
-  config:
-    activate:
-      on-profile: dev
 cors:
   allowed-origins: http://localhost:8080

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${AUTH0_ISSUER}}
+
+auth0:
+  audience: ${AUTH0_AUDIENCE} # https://tokoro-back-133c2efe4dcf.herokuapp.com
+  issuer: ${AUTH0_ISSUER} # https://dev-dngu4n3glnkuwbbp.us.auth0.com/
+
+cors:
+  allowed-origins: https://tokoro-front-c982e0550f7e.herokuapp.com/

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,16 +1,8 @@
 spring:
-  config:
-    activate:
-      on-profile: prod
   security:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${AUTH0_ISSUER}}
-
-auth0:
-  audience: ${AUTH0_AUDIENCE} # https://tokoro-back-133c2efe4dcf.herokuapp.com
-  issuer: ${AUTH0_ISSUER} # https://dev-dngu4n3glnkuwbbp.us.auth0.com/
-
+          issuer-uri: ${AUTH0_ISSUER}
 cors:
   allowed-origins: https://tokoro-front-c982e0550f7e.herokuapp.com/

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=tokoro
+management.endpoints.web.exposure.include=health
+spring.profiles.active=${SPRING_PROFILES_ACTIVE:prod}


### PR DESCRIPTION
- Configured allowed origins for CORS to permit frontend URLs (production and development environments).
- Implemented OAuth2 resource server with JWT validation for secured API endpoints.
- Updated security filter chain to enable OAuth2 authentication in production and permit all requests in development.