### PR TITLE
Update API URL in environment configuration

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-﻿NEXT_PUBLIC_API_URL=https://api.tokoro.space/api
+﻿NEXT_PUBLIC_API_URL=https://api.tokoro.space

--- a/frontend/app/(landing)/page.tsx
+++ b/frontend/app/(landing)/page.tsx
@@ -7,6 +7,9 @@ import Testimonials from '@/components/landing/testimonials/testimonials';
 import CallToAction from '@/components/landing/call-to-action/call-to-action';
 import { PlaceClient } from '@/lib/requests/place.client';
 
+// Make sure this page is always dynamic (because of fetching)
+export const dynamic = 'force-dynamic';
+
 export default async function Home() {
   const places = await PlaceClient.getRandomPlaces(20);
 


### PR DESCRIPTION
This pull request includes a small change to the `frontend/.env` file. The change modifies the `NEXT_PUBLIC_API_URL` to remove the `/api` endpoint.

* [`frontend/.env`](diffhunk://#diff-73e4ac151372ac43d9e0c6620f9781df4b013b88c0f1439f0f6f63445ab84d33L1-R1): Changed `NEXT_PUBLIC_API_URL` from `https://api.tokoro.space/api` to `https://api.tokoro.space`.